### PR TITLE
Renaming brag document link - dgoscn site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,7 @@ title = "Somebody Find Diego"
   title = "Hey 👋 I'm Diego Amaral"
   tagline = "Site Reliability Engineer"
   description = "Here, you will find some links and basic info about me"
-  contact = "https://dgoscn.simple.ink/"
+  contact = "https://dgooscn.thesimple.ink/"
 
 [params.homepage.codepen]
   username = "apvarun"


### PR DESCRIPTION

This pull request includes a small update to the `config.toml` file. The change updates the `contact` URL to a new domain.