### PR TITLE
correcting workflow actions version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying GitHub Pages by upgrading the `actions/upload-pages-artifact` action to a newer version.

Workflow update:

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L64-R64): Upgraded `actions/upload-pages-artifact` from version `v1` to `v3`, likely to take advantage of new features, improvements, or fixes in the updated version.