### PR TITLE
correcting workflow actions version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration. The change replaces the `actions/upload-pages-artifact@v3` action with `actions/upload-artifact@v3` in the `.github/workflows/gh-pages.yml` file for artifact uploading.