### PR TITLE
correcting build hugo 

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -52,14 +52,17 @@ jobs:
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
         env:
-          # For maximum backward compatibility with Hugo modules
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
           hugo \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"          
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+          if [ ! -d "./public" ]; then
+            echo "Error: Hugo did not generate the ./public directory."
+            exit 1
+          fi         
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This pull request introduces a validation step to ensure the Hugo build process generates the expected output directory. The change improves the reliability of the GitHub Actions workflow for deploying the site.

Validation added to Hugo build step:

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L55-R65): Added a check to confirm the `./public` directory is generated after running the Hugo build. If the directory is missing, the workflow will log an error and exit with a failure status.