### PR TITLE
correction on ubuntu ci image

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ defaults:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       HUGO_VERSION: 0.111.3
     steps:
@@ -73,7 +73,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the `gh-pages` deployment process to use a specific version of the Ubuntu runner. The changes ensure consistency and compatibility with the defined environment.

### Workflow updates:

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L33-R33): Updated the `runs-on` parameter for both the `build` and `jobs` sections to use `ubuntu-22.04` instead of `ubuntu-latest`. [[1]](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L33-R33) [[2]](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L76-R76)